### PR TITLE
allow tourney manager login use tourney client

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -722,17 +722,16 @@ async def handle_osu_login_request(
             ),
         }
 
-    if osu_version.stream is OsuStream.TOURNEY and not (
-        user_info["priv"] & Privileges.DONATOR
-        and user_info["priv"] & Privileges.UNRESTRICTED
-    ):
-        # trying to use tourney client with insufficient privileges.
-        return {
-            "osu_token": "no",
-            "response_body": app.packets.login_reply(
-                LoginFailureReason.AUTHENTICATION_FAILED,
-            ),
-        }
+    if osu_version.stream is OsuStream.TOURNEY:
+        allowed_priv = Privileges.DONATOR | Privileges.TOURNEY_MANAGER | Privileges.UNRESTRICTED
+        if user_info["priv"] & allowed_priv <= Privileges.UNRESTRICTED:
+            # trying to use tourney client with insufficient privileges.
+            return {
+                "osu_token": "no",
+                "response_body": app.packets.login_reply(
+                    LoginFailureReason.AUTHENTICATION_FAILED,
+                ),
+            }
 
     """ login credentials verified """
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
Allow TOURNEY_MANAGER priv to log in with tourney client

## Related Issues / Projects
https://github.com/osuAkatsuki/bancho.py/pull/715

## Checklist
- [ ] I've manually tested my code
