### PR TITLE
基于vsrg total analyzer的mania反作弊更新

### DIFF
--- a/app/repositories/scores_suspicion.py
+++ b/app/repositories/scores_suspicion.py
@@ -14,6 +14,7 @@ class SuspicionKind(StrEnum):
     REPLAY = "replay"
     HASH = "hash"
     REPORT = "report"
+    MANIA = "mania"
 
 class ScoresSuspicionTable(Base):
     __tablename__ = "scores_suspicion"
@@ -71,5 +72,16 @@ async def has_suspicion(user_id) -> bool:
         WHERE us.id=:user_id",
         {"user_id": user_id}
     )
-    
+
+
+async def count_mania_suspicion(user_id) -> int:
+    """统计该玩家已有的 mania 按压异常 suspicion 数量."""
+    row = await app.state.services.database.fetch_one(
+        "SELECT COUNT(*) AS cnt FROM scores_suspicion su \
+        JOIN scores sc ON su.score_id=sc.id \
+        WHERE sc.userid=:user_id AND su.kind=:kind",
+        {"user_id": user_id, "kind": SuspicionKind.MANIA}
+    )
+    return int(row["cnt"]) if row and row["cnt"] is not None else 0
+
     

--- a/app/usecases/anticheat.py
+++ b/app/usecases/anticheat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import struct
 from pathlib import Path
@@ -20,6 +21,7 @@ from app.objects.player import Player
 from app.objects.score import Score
 from app.repositories import scores_suspicion
 from app.repositories.scores_suspicion import SuspicionKind
+from app.usecases import mania_anticheat
 
 REPLAYS_PATH = Path.cwd() / ".data/osr"
 BEATMAPS_PATH = Path.cwd() / ".data/osu"
@@ -185,7 +187,60 @@ async def validate_checksum(
         await _save_suspicion(player, score, SuspicionKind.HASH, error.args[0], detail)
 
 
+async def validate_mania_replay(score: Score, beatmap: Beatmap, player: Player):
+    """对 mania 回放执行 pressing time 异常检测 (仅记录 suspicion).
+
+    circleguard 的 UR/snaps 基于 2D 距离计算, 对 mania 无意义, 故跳过.
+    """
+    try:
+        detail: dict = {}
+
+        has_relax = score.mods & Mods.RELAX or score.mods & Mods.AUTOPILOT
+        if not has_relax:
+            replay_file = REPLAYS_PATH / f"{score.id}.osr"
+            if replay_file.exists():
+                # CPU 密集的解析/检测放入线程池, 避免阻塞事件循环
+                anomaly = await asyncio.to_thread(
+                    mania_anticheat.analyze_replay_file,
+                    replay_file,
+                )
+                if anomaly is not None:
+                    detail = anomaly
+                    # 玩家确认制: 该玩家已有 mania suspicion 时, 本次记录升级为确认级
+                    prev_suspicions = await scores_suspicion.count_mania_suspicion(
+                        player.id,
+                    )
+                    anomaly["confirmed"] = prev_suspicions > 0
+
+                    await _save_suspicion(
+                        player,
+                        score,
+                        SuspicionKind.MANIA,
+                        f"mania pressing-time anomaly (criteria: {anomaly['criteria']})",
+                        anomaly,
+                    )
+
+        # ppcap 检查对所有模式生效, 保持原行为
+        if score.bmap and score.bmap.awards_ranked_pp and score.pp > PPCAP[score.mode]:
+            await _save_suspicion(
+                player,
+                score,
+                SuspicionKind.PPCAP,
+                f"ppcap threshold exceeded (pp: {score.pp:.2f} / {PPCAP[score.mode]})",
+                detail,
+            )
+    except Exception as e:
+        log(
+            f"Failed to check the mania score ({score.id} by {player.name}) due to {repr(e)}, skipped.",
+            Ansi.RED,
+        )
+
+
 async def validate_replay(score: Score, beatmap: Beatmap, player: Player):
+    if score.mode.as_vanilla == GameMode.VANILLA_MANIA:
+        await validate_mania_replay(score, beatmap, player)
+        return
+
     try:
         has_relax = score.mods & Mods.RELAX or score.mods & Mods.AUTOPILOT
         replay, slider_beatmap = _parse_score(score, beatmap, player)

--- a/app/usecases/anticheat.py
+++ b/app/usecases/anticheat.py
@@ -199,10 +199,18 @@ async def validate_mania_replay(score: Score, beatmap: Beatmap, player: Player):
         if not has_relax:
             replay_file = REPLAYS_PATH / f"{score.id}.osr"
             if replay_file.exists():
+                # mania 中谱面 CS = 键数 (4/7/9/16/18K 等); 异常时由
+                # 检测器从回放数据推断, 避免 4K 抬起位被误读为额外列
+                try:
+                    keyc = int(round(beatmap.cs))
+                except (TypeError, ValueError):
+                    keyc = None
+
                 # CPU 密集的解析/检测放入线程池, 避免阻塞事件循环
                 anomaly = await asyncio.to_thread(
                     mania_anticheat.analyze_replay_file,
                     replay_file,
+                    keyc,
                 )
                 if anomaly is not None:
                     detail = anomaly

--- a/app/usecases/mania_anticheat.py
+++ b/app/usecases/mania_anticheat.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import lzma
+import statistics
+from pathlib import Path
+from typing import Optional
+
+# 按压时长截断上限 (ms), 超过视为长按误触/暂停等, 不参与统计
+MAX_DURATION = 300
+# 时长直方图范围 (ms)
+HIST_RANGE = 200
+# 最低按压数, 低于此值跳过检测 (低样本易偶然形成作弊图形)
+MIN_PRESSES = 500
+# 峰值规则所需最低按压数
+MIN_PRESSES_PEAK = 1500
+# 局部极大值判定窗口 (ms)
+PEAK_WINDOW = 2
+# 频数底过滤比例 (低于 0.1 * 最高峰频数的 bin 忽略)
+PEAK_FLOOR_RATIO = 0.1
+# 强峰判定比例 (> 0.25 * 最高峰频数); 0.30 会放过次峰位于
+# 0.25-0.30 区间的临界文件 (如 vibro 3261953), 0.25 以下开始漏检
+STRONG_PEAK_RATIO = 0.25
+# 判据 A: 按压时长中位数上限 (ms)
+MEDIAN_LIMIT = 32
+# 判据 B: <20ms 按压占比下限
+LT20_LIMIT = 0.15
+# 判据 D: 单 bin 峰值占总按压数比例下限
+DOM1_LIMIT = 0.12
+
+
+def parse_replay_data(raw: bytes) -> list[tuple[int, int]]:
+    """解析服务器存储的 replay 数据 (lzma 压缩的文本帧).
+
+    帧格式: "时间增量ms|按键状态位掩码|固定帧间隔|0", 以逗号分隔.
+    """
+    text = lzma.decompress(raw).decode("utf-8", errors="replace")
+    frames: list[tuple[int, int]] = []
+    for frame in text.split(","):
+        parts = frame.split("|")
+        if len(parts) != 4:
+            continue
+        try:
+            dt = int(parts[0])
+            keys = int(parts[1])
+        except ValueError:
+            continue
+        frames.append((dt, keys))
+    return frames
+
+
+def compute_press_durations(
+    frames: list[tuple[int, int]],
+    keyc: int = 9,
+) -> list[float]:
+    """按列跟踪按键按下/抬起, 计算每次按压的持续时间 (ms)."""
+    held = [False] * keyc
+    press_t = [0.0] * keyc
+    durations: list[float] = []
+    t = 0.0
+    for dt, keys in frames:
+        if dt <= 0 or keys < 0:
+            # 跳过垃圾帧 (-12345 等) 与无效帧
+            continue
+        t += dt
+        for k in range(keyc):
+            down = (keys >> k) & 1
+            if down and not held[k]:
+                held[k] = True
+                press_t[k] = t
+            elif not down and held[k]:
+                held[k] = False
+                durations.append(t - press_t[k])
+    return durations
+
+
+def _build_histogram(durations: list[float]) -> list[int]:
+    hist = [0] * HIST_RANGE
+    for d in durations:
+        if d < HIST_RANGE:
+            hist[int(d)] += 1
+    return hist
+
+
+def _count_other_strong_peaks(hist: list[int]) -> int:
+    """局部极大值(±2ms) -> 过滤 <0.1*max 的频数 -> 统计排除最高峰后
+    高于 0.3*max 的峰数量."""
+    maxv = max(hist)
+    if maxv <= 0:
+        return 0
+
+    local_maxima = []
+    for i in range(PEAK_WINDOW, HIST_RANGE - PEAK_WINDOW):
+        if hist[i] > 0 and all(
+            hist[i] >= hist[i - j] for j in range(1, PEAK_WINDOW + 1)
+        ) and all(
+            hist[i] > hist[i + j] for j in range(1, PEAK_WINDOW + 1)
+        ):
+            local_maxima.append(i)
+
+    floor = PEAK_FLOOR_RATIO * maxv
+    kept = [i for i in local_maxima if hist[i] >= floor]
+    if not kept:
+        return 0
+    max_at = max(kept, key=lambda i: hist[i])
+    return sum(
+        1 for i in kept if i != max_at and hist[i] > STRONG_PEAK_RATIO * maxv
+    )
+
+
+def analyze_replay_file(path: Path) -> Optional[dict]:
+    """读取服务器存储的 replay 文件并检测按压异常 (同步函数, 供线程池调用)."""
+    frames = parse_replay_data(path.read_bytes())
+    durations = compute_press_durations(frames)
+    return detect_pressing_anomaly(durations)
+
+
+def detect_pressing_anomaly(durations: list[float]) -> Optional[dict]:
+    """检测 pressing time 异常.
+
+    任一判据命中即返回详情, 否则返回 None:
+    A. 峰值规则: 其余强峰 <=1 且中位数 < 32ms (n>=1500)
+    B. 短按占比: <20ms 按压占比 > 15% (n>=500)
+    D. 峰值占比: 单 bin 峰值 / 总按压数 > 12% (n>=500)
+    """
+    d300 = [d for d in durations if d <= MAX_DURATION]
+    n = len(d300)
+    if n < MIN_PRESSES:
+        return None
+
+    hist = _build_histogram(d300)
+    maxv = max(hist)
+    med = statistics.median(d300)
+    lt20 = sum(1 for d in d300 if d < 20) / n
+    dom1 = maxv / n
+    osc = _count_other_strong_peaks(hist)
+
+    criteria: list[str] = []
+    if n >= MIN_PRESSES_PEAK and osc <= 1 and med < MEDIAN_LIMIT:
+        criteria.append("A")
+    if lt20 > LT20_LIMIT:
+        criteria.append("B")
+    if dom1 > DOM1_LIMIT:
+        criteria.append("D")
+
+    if not criteria:
+        return None
+
+    return {
+        "criteria": "+".join(criteria),
+        "n_presses": n,
+        "median_ms": round(med, 1),
+        "lt20_ratio": round(lt20, 4),
+        "peak_dominance": round(dom1, 4),
+        "other_strong_peaks": osc,
+    }

--- a/app/usecases/mania_anticheat.py
+++ b/app/usecases/mania_anticheat.py
@@ -7,8 +7,11 @@ from typing import Optional
 
 # 按压时长截断上限 (ms), 超过视为长按误触/暂停等, 不参与统计
 MAX_DURATION = 300
-# 时长直方图范围 (ms)
-HIST_RANGE = 200
+# 时长直方图范围 (ms), 与 MAX_DURATION 保持一致, 保证
+# 峰值占比 (dom1) 的分子分母来自同一数据集
+HIST_RANGE = MAX_DURATION
+# 最高支持键数 (mania 最高 18K, 位掩码需 18 位)
+MAX_KEYCOUNT = 18
 # 最低按压数, 低于此值跳过检测 (低样本易偶然形成作弊图形)
 MIN_PRESSES = 500
 # 峰值规则所需最低按压数
@@ -26,6 +29,10 @@ MEDIAN_LIMIT = 32
 LT20_LIMIT = 0.15
 # 判据 D: 单 bin 峰值占总按压数比例下限
 DOM1_LIMIT = 0.12
+# 10K+ 谱面按压分摊到更多列, 分布天然更集中, D 阈值放宽
+# (16K 正常玩家实测最高 12.6%, 与 4K 作弊的 12.2-12.4% 无法同阈值区分)
+HIGH_KEYC_THRESHOLD = 10
+DOM1_LIMIT_HIGH_KEYC = 0.14
 
 
 def parse_replay_data(raw: bytes) -> list[tuple[int, int]]:
@@ -50,16 +57,24 @@ def parse_replay_data(raw: bytes) -> list[tuple[int, int]]:
 
 def compute_press_durations(
     frames: list[tuple[int, int]],
-    keyc: int = 9,
+    keyc: int = 4,
 ) -> list[float]:
-    """按列跟踪按键按下/抬起, 计算每次按压的持续时间 (ms)."""
+    """按列跟踪按键按下/抬起, 计算每次按压的持续时间 (ms).
+
+    只统计低 `keyc` 位 (按下 = 位 0->1, 抬起 = 位 1->0):
+    - 4K 及以下: keys 低 4 位为按下状态, 高 4 位为抬起位 (stable 遗留
+      编码), 抬起位直接忽略, 状态位变化即可表达抬起
+    - 5K-16K (lazer): keys 为纯状态位掩码 (bit i = 第 i+1 键按下)
+    keyc 由谱面键数 (beatmap.cs) 或 infer_keycount 提供, 避免把 4K 的
+    抬起位误读为额外列 (此前固定 9 列会污染 B/D 判据特征).
+    """
     held = [False] * keyc
     press_t = [0.0] * keyc
     durations: list[float] = []
     t = 0.0
     for dt, keys in frames:
         if dt <= 0 or keys < 0:
-            # 跳过垃圾帧 (-12345 等) 与无效帧
+            # 跳过垃圾帧 (-12345 RNG seed 帧等) 与无效帧
             continue
         t += dt
         for k in range(keyc):
@@ -71,6 +86,30 @@ def compute_press_durations(
                 held[k] = False
                 durations.append(t - press_t[k])
     return durations
+
+
+def infer_keycount(frames: list[tuple[int, int]]) -> int:
+    """从回放数据推断按键列数 (无谱面信息时的兜底).
+
+    4K 及以下的 stable 编码: 高 4 位 (抬起位) 是低 4 位 (按下位) 的
+    子集 (同一帧只能抬起当前按下的键). 若观察到违反该约束的值, 说明是
+    纯状态位编码 (5K-16K), 键数 = 最高置位位数.
+    """
+    max_keys = 0
+    is_state_mask = False
+    for dt, keys in frames:
+        if dt <= 0 or keys < 0:
+            continue
+        max_keys = max(max_keys, keys)
+        # 高 4 位存在低 4 位没有的位 -> 纯状态位编码
+        if (keys >> 4) & ~(keys & 0x0F):
+            is_state_mask = True
+
+    if max_keys == 0:
+        return 4
+    if is_state_mask:
+        return min(max_keys.bit_length(), MAX_KEYCOUNT)
+    return 4
 
 
 def _build_histogram(durations: list[float]) -> list[int]:
@@ -107,20 +146,29 @@ def _count_other_strong_peaks(hist: list[int]) -> int:
     )
 
 
-def analyze_replay_file(path: Path) -> Optional[dict]:
-    """读取服务器存储的 replay 文件并检测按压异常 (同步函数, 供线程池调用)."""
+def analyze_replay_file(path: Path, keyc: Optional[int] = None) -> Optional[dict]:
+    """读取服务器存储的 replay 文件并检测按压异常 (同步函数, 供线程池调用).
+
+    keyc 为谱面键数 (mania 的 beatmap.cs); 为 None 时从回放数据推断.
+    """
     frames = parse_replay_data(path.read_bytes())
-    durations = compute_press_durations(frames)
-    return detect_pressing_anomaly(durations)
+    if keyc is None:
+        keyc = infer_keycount(frames)
+    durations = compute_press_durations(frames, keyc)
+    return detect_pressing_anomaly(durations, keyc)
 
 
-def detect_pressing_anomaly(durations: list[float]) -> Optional[dict]:
+def detect_pressing_anomaly(
+    durations: list[float],
+    keyc: int = 4,
+) -> Optional[dict]:
     """检测 pressing time 异常.
 
     任一判据命中即返回详情, 否则返回 None:
     A. 峰值规则: 其余强峰 <=1 且中位数 < 32ms (n>=1500)
     B. 短按占比: <20ms 按压占比 > 15% (n>=500)
-    D. 峰值占比: 单 bin 峰值 / 总按压数 > 12% (n>=500)
+    D. 峰值占比: 单 bin 峰值 / 总按压数 > 12% (n>=500); 10K+ 谱面
+       阈值放宽至 14%
     """
     d300 = [d for d in durations if d <= MAX_DURATION]
     n = len(d300)
@@ -134,12 +182,16 @@ def detect_pressing_anomaly(durations: list[float]) -> Optional[dict]:
     dom1 = maxv / n
     osc = _count_other_strong_peaks(hist)
 
+    dom1_limit = (
+        DOM1_LIMIT_HIGH_KEYC if keyc >= HIGH_KEYC_THRESHOLD else DOM1_LIMIT
+    )
+
     criteria: list[str] = []
     if n >= MIN_PRESSES_PEAK and osc <= 1 and med < MEDIAN_LIMIT:
         criteria.append("A")
     if lt20 > LT20_LIMIT:
         criteria.append("B")
-    if dom1 > DOM1_LIMIT:
+    if dom1 > dom1_limit:
         criteria.append("D")
 
     if not criteria:

--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -475,3 +475,7 @@ create index users_country_index
 # v5.2.2
 create index scores_fetch_leaderboard_generic_index
 	on scores (map_md5, status, mode);
+
+# v5.3.0
+alter table scores_suspicion modify kind enum('ppcap', 'replay', 'hash', 'report', 'mania') not null;
+


### PR DESCRIPTION
## 概述

为 mania 模式增加专门的 pressing time 反作弊检测，针对按压时长呈单峰/双峰异常分布的作弊（时间变速 + 模拟人类按压的作弊工具）。

## 背景

- 服务器存储的 replay 数据是 lzma 压缩的**文本帧**格式（`时间增量|按键状态|帧间隔|0`），而 circleguard 按二进制帧解析会得到乱码帧，UR/snaps 对 mania 无意义且开销大（200ms-1s+/分）
- 人类按键物理极限约 30-40ms，作弊按压时长高度集中于 10-25ms 且分布呈现单峰主导/等距峰

## 改动

1. 新增 `app/usecases/mania_anticheat.py`：解析文本帧 → 按列跟踪按压时长 → 三判据检测：
   - **A 峰值规则**：直方图局部极大值（±2ms），过滤 <0.1×max 频数，排除最高峰后 >0.25×max 的峰 ≤1 且中位数 <32ms（n≥1500）
   - **B 短按占比**：<20ms 按压占比 >15%（n≥500）
   - **D 峰值占比**：单 bin 峰值/总按压数 >12%（n≥500；10K+ 谱面放宽至 14%）
2. **键数处理**：只统计低 keyc 位（4K 及以下的稳定版抬起位编码、5K-18K 的 lazer 纯状态位编码均正确解析）；keyc 优先取谱面 CS（mania 中 CS=键数），否则从回放数据推断
3. `validate_replay` 对 mania 分流到新检测器（跳过 circleguard），CPU 密集部分用 `asyncio.to_thread` 避免阻塞事件循环；保留 PPCAP 检查
4. `SuspicionKind` 新增 `MANIA`；`count_mania_suspicion` 实现玩家确认制（同玩家 ≥2 次命中标记 confirmed）
5. 迁移文件新增 v5.3.0：`kind` 枚举增加 `mania`

## 验证（标注数据集）

| 分类 | 命中/误杀 |
|---|---|
| 单峰值（作弊，25 个回放） | 23/25 (92%) |
| 双峰值（作弊，74 个回放） | 72/74 (97%) |
| 正常玩家（低采样/高准度/vibro/pp图/7k/16k，174 个回放） | 0 误杀 |

每分开销约 15-23ms（纯标准库解析），仅记录 suspicion 不自动冻结。

---

不会误判低设备采样率玩家，如图
<img width="1589" height="593" alt="solo-replay-mania_4376982_6713473057_duration_spectrum" src="https://github.com/user-attachments/assets/bd55fe7f-1651-4826-9ee3-99d5a0d2fd28" />
或者高准度玩家（可能会产生普通玩家打不出来的峰值）
<img width="1589" height="593" alt="solo-replay-mania_5425091_6465893487_duration_spectrum" src="https://github.com/user-attachments/assets/d14eca91-d146-460c-9ff6-cb4c5b85e99b" />
